### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clj-webdriver-boilerplate "0.1.0-SNAPSHOT"
+(defproject clj-webdriver-boilerplate "0.6.1"
   :description "clj-web-driver-boilerplate" 
-  :url "http://www.github.com/greywolve/clj-webdriver-boilerplate"
+  :url "https://www.github.com/greywolve/clj-webdriver-boilerplate"
   :license {:name "MIT License"
             :url "https://github.com/greywolve/clj-webdriver-boilerplate/blob/master/LICENSE"}
   :dependencies [[org.clojure/clojure "1.5.1"]


### PR DESCRIPTION
Plan is to match clj-webdriver version.