### PR TITLE
Bump selenium version to support Firefox 47+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://github.com/greywolve/clj-webdriver-boilerplate/blob/master/LICENSE"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [clj-webdriver "0.7.2"]
-                 [org.seleniumhq.selenium/selenium-java "2.53.0"]
+                 [org.seleniumhq.selenium/selenium-java "2.53.1"]
                  ; > Starting with 2.53.0 you need to explicitly include HtmlUnitDriver as a dependency to include it.
                  ; > Version number of the driver is now tracking HtmlUnit itself.
                  ; Source: http://www.seleniumhq.org/download/maven.jsp


### PR DESCRIPTION
Otherwise it fails with such an error:

```
pair@flappy ~/g/o/clj-webdriver-boilerplate> lein with-browser test
org.openqa.selenium.firefox.NotConnectedException: Unable to connect to host 127.0.0.1 on port 7055 after 45000 ms. Firefox console output:
-a285-3208198ce6fd}","syncGUID":"eLW6pjXyQ-RP","location":"app-global","version":"47.0.1","type":"theme","internalName":"classic/1.0","updateURL":null,"updateKey":null,"optionsURL":null,"optionsType":null,"aboutURL":null,"icons":{"32":"icon.png","48":"icon.png"},"iconURL":null,"icon64URL":null,"defaultLocale":{"name":"Default","description":"The default theme.","creator":"Mozilla","homepageURL":null,"contributors":["Mozilla Contributors"]},"visible":true,"active":true,"userDisabled":false,"appDisabled":false,"descriptor":"/Applications/Firefox.app/Contents/Resources/browser/extensions/{972ce4c6-7e08-4474-a285-3208198ce6fd}.xpi","installDate":1466727371000,"updateDate":1466727371000,"applyBackgroundUpdates":1,"skinnable":true,"size":7140,"sourceURI":null,"releaseNotesURI":null,"softDisabled":false,"foreignInstall":false,"hasBinaryComponents":false,"strictCompatibility":true,"locales":[],"targetApplications":[{"id":"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}","minVersion":"47.0.1","maxVersion":"47.0.1"}],"targetPlatforms":[],"seen":true}
1467774362516   addons.xpi  DEBUG   getModTime: Recursive scan of {972ce4c6-7e08-4474-a285-3208198ce6fd}
1467774362517   DeferredSave.extensions.json    DEBUG   Save changes
1467774362517   addons.xpi  DEBUG   Updating database with changes to installed add-ons
1467774362517   addons.xpi-utils    DEBUG   Updating add-on states
1467774362518   addons.xpi-utils    DEBUG   Writing add-ons list
1467774362519   addons.xpi  DEBUG   Registering manifest for /Applications/Firefox.app/Contents/Resources/browser/features/e10srollout@mozilla.org.xpi
1467774362519   addons.xpi  DEBUG   Calling bootstrap method startup on e10srollout@mozilla.org version 1.0
1467774362519   addons.xpi  DEBUG   Registering manifest for /Applications/Firefox.app/Contents/Resources/browser/features/firefox@getpocket.com.xpi
1467774362520   addons.xpi  DEBUG   Calling bootstrap method startup on firefox@getpocket.com version 1.0.2
1467774362521   addons.xpi  DEBUG   Registering manifest for /Applications/Firefox.app/Contents/Resources/browser/features/loop@mozilla.org.xpi
1467774362521   addons.xpi  DEBUG   Calling bootstrap method startup on loop@mozilla.org version 1.3.2
1467774362545   addons.manager  DEBUG   Registering shutdown blocker for XPIProvider
1467774362546   addons.manager  DEBUG   Provider finished startup: XPIProvider
1467774362546   addons.manager  DEBUG   Starting provider: LightweightThemeManager
1467774362546   addons.manager  DEBUG   Registering shutdown blocker for LightweightThemeManager
1467774362546   addons.manager  DEBUG   Provider finished startup: LightweightThemeManager
1467774362547   addons.manager  DEBUG   Starting provider: GMPProvider
1467774362556   addons.manager  DEBUG   Registering shutdown blocker for GMPProvider
1467774362556   addons.manager  DEBUG   Provider finished startup: GMPProvider
1467774362557   addons.manager  DEBUG   Starting provider: PluginProvider
1467774362557   addons.manager  DEBUG   Registering shutdown blocker for PluginProvider
1467774362557   addons.manager  DEBUG   Provider finished startup: PluginProvider
1467774362557   addons.manager  DEBUG   Completed startup sequence
1467774362872   addons.manager  DEBUG   Starting provider: <unnamed-provider>
1467774362872   addons.manager  DEBUG   Registering shutdown blocker for <unnamed-provider>
1467774362872   addons.manager  DEBUG   Provider finished startup: <unnamed-provider>
1467774362878   DeferredSave.extensions.json    DEBUG   Starting write
1467774362987   addons.repository   DEBUG   No addons.json found.
1467774362988   DeferredSave.addons.json    DEBUG   Save changes
1467774362992   DeferredSave.addons.json    DEBUG   Starting timer
1467774363018   addons.manager  DEBUG   Starting provider: PreviousExperimentProvider
1467774363018   addons.manager  DEBUG   Registering shutdown blocker for PreviousExperimentProvider
1467774363018   addons.manager  DEBUG   Provider finished startup: PreviousExperimentProvider
1467774363029   DeferredSave.extensions.json    DEBUG   Write succeeded
1467774363030   addons.xpi-utils    DEBUG   XPI Database saved, setting schema version preference to 17
1467774363051   DeferredSave.addons.json    DEBUG   Starting write
1467774363062   DeferredSave.addons.json    DEBUG   Write succeeded

    at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.start(NewProfileExtensionConnection.java:113)
    at org.openqa.selenium.firefox.FirefoxDriver.startClient(FirefoxDriver.java:271)
    at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:119)
    at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:216)
    at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:211)
    at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:207)
    at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:120)
    at clj_webdriver.core$eval3566$fn__3568.invoke(core.clj:198)
    at clojure.lang.MultiFn.invoke(MultiFn.java:229)
    at clj_webdriver.core$new_driver.invokeStatic(core.clj:241)
    at clj_webdriver.core$new_driver.invoke(core.clj:230)
    at clj_webdriver.taxi$set_driver_STAR_.invokeStatic(taxi.clj:26)
    at clj_webdriver.taxi$set_driver_STAR_.invoke(taxi.clj:21)
    at clj_webdriver.taxi$set_driver_BANG_.invokeStatic(taxi.clj:59)
    at clj_webdriver.taxi$set_driver_BANG_.invoke(taxi.clj:33)
    at clj_webdriver_boilerplate.core$browser_up.invokeStatic(core.clj:10)
    at clj_webdriver_boilerplate.core$browser_up.invoke(core.clj:6)
    at leiningen.with_browser$with_browser.invokeStatic(with_browser.clj:8)
    at leiningen.with_browser$with_browser.doInvoke(with_browser.clj:5)
    at clojure.lang.RestFn.invoke(RestFn.java:425)
    at clojure.lang.Var.invoke(Var.java:383)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.core$apply.invokeStatic(core.clj:648)
    at clojure.core$apply.invoke(core.clj:641)
    at leiningen.core.main$partial_task$fn__5829.doInvoke(main.clj:272)
    at clojure.lang.RestFn.applyTo(RestFn.java:139)
    at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invokeStatic(core.clj:648)
    at clojure.core$apply.invoke(core.clj:641)
    at leiningen.core.main$apply_task.invokeStatic(main.clj:322)
    at leiningen.core.main$apply_task.invoke(main.clj:308)
    at leiningen.core.main$resolve_and_apply.invokeStatic(main.clj:328)
    at leiningen.core.main$resolve_and_apply.invoke(main.clj:324)
    at leiningen.core.main$_main$fn__5895.invoke(main.clj:401)
    at leiningen.core.main$_main.invokeStatic(main.clj:394)
    at leiningen.core.main$_main.doInvoke(main.clj:391)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:383)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.core$apply.invokeStatic(core.clj:646)
    at clojure.main$main_opt.invokeStatic(main.clj:314)
    at clojure.main$main_opt.invoke(main.clj:310)
    at clojure.main$main.invokeStatic(main.clj:421)
    at clojure.main$main.doInvoke(main.clj:384)
    at clojure.lang.RestFn.invoke(RestFn.java:457)
    at clojure.lang.Var.invoke(Var.java:394)
    at clojure.lang.AFn.applyToHelper(AFn.java:165)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.main.main(main.java:37)
```
